### PR TITLE
Handle environment flags in qmake (CFLAGS, CXXFLAGS, LDFLAGS)

### DIFF
--- a/configure
+++ b/configure
@@ -116,6 +116,10 @@ fi
 QMAKE_CACHE=`pwd`/.qmake.cache
 [ -f $QMAKE_CACHE ] && rm -f $QMAKE_CACHE
 
+[ -n "$CFLAGS" ]   && echo "QMAKE_CFLAGS += ${CFLAGS}"     >> $QMAKE_CACHE
+[ -n "$CXXFLAGS" ] && echo "QMAKE_CXXFLAGS += ${CXXFLAGS}" >> $QMAKE_CACHE
+[ -n "$LDFLAGS" ]  && echo "QMAKE_LFLAGS += ${LDFLAGS}"    >> $QMAKE_CACHE
+
 [ -z "$PKG_CONFIG" ] && PKG_CONFIG=pkg-config
 echo "PKG_CONFIG = $PKG_CONFIG" >> $QMAKE_CACHE
 


### PR DESCRIPTION
Give the user the option to use environment flags to optimize build.
(also rpm based linux distributions will warn that files are compiled without optimization flags when they can not give the compiler their own flags).