### PR TITLE
VLC: Interpolate playback position

### DIFF
--- a/src/interfaces/playbackEngineInterface.h
+++ b/src/interfaces/playbackEngineInterface.h
@@ -33,7 +33,7 @@ public:
     Q_INVOKABLE virtual N::PlaybackState state() const = 0;
 
     Q_INVOKABLE virtual qreal volume() const = 0;
-    Q_INVOKABLE virtual qreal position() const = 0;
+    Q_INVOKABLE virtual qreal position() = 0;
     Q_INVOKABLE virtual qint64 durationMsec() const = 0;
 
     static QString interfaceString() { return PLAYBACK_INTERFACE; }

--- a/src/plugins/vlc/playbackEngineVlc.cpp
+++ b/src/plugins/vlc/playbackEngineVlc.cpp
@@ -61,6 +61,7 @@ void NPlaybackEngineVlc::init()
 
     m_oldVolume = -1;
     m_oldPosition = -1;
+    m_oldTime = -1;
     m_oldState = N::PlaybackStopped;
 
     m_timer = new QTimer(this);
@@ -123,12 +124,23 @@ void NPlaybackEngineVlc::setPosition(qreal pos)
     libvlc_media_player_set_position(m_mediaPlayer, qBound(0.0, pos, 1.0));
 }
 
-qreal NPlaybackEngineVlc::position() const
+qreal NPlaybackEngineVlc::position()
 {
     if (!hasMedia())
         return -1;
 
-    return libvlc_media_player_get_position(m_mediaPlayer);
+    // VLC only updates the position a few times per second. To avoid choppy
+    // movement of the position indicator, interpolate from the last updated
+    // position.
+    qint64 time = libvlc_media_player_get_time(m_mediaPlayer);
+    qint64 duration = libvlc_media_player_get_length(m_mediaPlayer);
+    if (time == m_oldTime && libvlc_media_player_get_state(m_mediaPlayer) == libvlc_Playing) {
+        time += m_positionTimer.elapsed();
+    } else {
+        m_oldTime = time;
+        m_positionTimer.start();
+    }
+    return (qreal) time / duration;
 }
 
 void NPlaybackEngineVlc::jump(qint64 msec)

--- a/src/plugins/vlc/playbackEngineVlc.h
+++ b/src/plugins/vlc/playbackEngineVlc.h
@@ -19,6 +19,7 @@
 #include "plugin.h"
 #include "playbackEngineInterface.h"
 #include <QTimer>
+#include <QTime>
 #include <vlc/vlc.h>
 #include <vlc_aout.h>
 
@@ -35,6 +36,8 @@ private:
     QTimer *m_timer;
     qreal m_oldVolume;
     qreal m_oldPosition;
+    qint64 m_oldTime;
+    QTime m_positionTimer;
     N::PlaybackState m_oldState;
     QString m_currentMedia;
 
@@ -50,7 +53,7 @@ public:
     Q_INVOKABLE N::PlaybackState state() const { return m_oldState; }
 
     Q_INVOKABLE qreal volume() const;
-    Q_INVOKABLE qreal position() const;
+    Q_INVOKABLE qreal position();
     Q_INVOKABLE qint64 durationMsec() const;
 
 public slots:


### PR DESCRIPTION
libvlc only updates the current playback position a few times per second, so the bar is always jumping forward. With this commit, the position is interpolated if libvlc returns an old position.

~~I based the commit on the release branch as I get compile errors on master. It applies cleanly on master as well.~~
Actually I just figured out that you have to `make clean` and re-configure when switching branches. I guess I'm too used to cmake/meson where all this happens automatically :)