### PR TITLE
skins: Do not save extra file attributes in .zip

### DIFF
--- a/src/skins/skins.pri
+++ b/src/skins/skins.pri
@@ -4,7 +4,7 @@ win32:SKIN_DEST_DIR = $$SRC_DIR/../Skins
 system($$QMAKE_MKDIR $$fixSlashes($$SKIN_DEST_DIR))
 
 unix {
-    ZIP_ADD_CMD = zip -j
+    ZIP_ADD_CMD = zip -j -X
     ZIP_DEL_CMD = zip -d
 }
 win32 {


### PR DESCRIPTION
Do not save extra file attributes in .zip (e.g. ctime, atime)
to make it easier to make a reproducible build
See https://reproducible-builds.org/ for why this is good.


Note: Build results became fully deterministic with
[this zip patch](https://build.opensuse.org/package/view_file/openSUSE:Factory/zip/reproducible.patch)

This PR was done while working on reproducible builds for openSUSE.