### PR TITLE
[Qt5] Fix LIBDIR

### DIFF
--- a/configure
+++ b/configure
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 BASENAME=$(basename $0)
-CWD=$(dirname $0)
+CWD="$(dirname $0)"
 PREFIX=/usr
 LIBDIR=lib
 DEBUG=no
@@ -84,7 +84,7 @@ while test $# -gt 0; do
     shift
 done
 
-QMAKE_CACHE=$CWD/.qmake.cache
+QMAKE_CACHE="$CWD"/.qmake.cache
 echo -n > $QMAKE_CACHE
 
 check_executable() {
@@ -171,7 +171,7 @@ else
 fi
 echo "PREFIX = $PREFIX" >> $QMAKE_CACHE
 
-echo "N_LIBDIR = $LIBDIR" >> $QMAKE_CACHE
+echo "LIBDIR = $LIBDIR" >> $QMAKE_CACHE
 echo "Library directory: $LIBDIR"
 
 echo "N_CONFIG_SUCCESS = yes" >> $QMAKE_CACHE

--- a/src/src.pro
+++ b/src/src.pro
@@ -4,5 +4,5 @@ DESTDIR = ..
 
 SRC_DIR = $$PWD
 include($$SRC_DIR/src.pri)
-DEFINES += N_LIBDIR=\""\\\"$${N_LIBDIR}\\\""\"
+DEFINES += N_LIBDIR=\""\\\"$${LIBDIR}\\\""\"
 SOURCES += $$SRC_DIR/main.cpp


### PR DESCRIPTION
It's defined as `N_LIBDIR` but used as `LIBDIR` in `src/plugins/plugin.pri`

Also quote `CWD` variable in `configure` script because it might contain spaces

It addresses the issue commented in https://github.com/nulloy/nulloy/issues/122#issuecomment-493658500