### PR TITLE
Fix seek-time UI deadlock, restore gapless, and fix GStreamer/TagLib resource bugs

### DIFF
--- a/src/playlistController.cpp
+++ b/src/playlistController.cpp
@@ -39,8 +39,14 @@ NPlaylistController::NPlaylistController(NPlaybackEngineInterface &playbackEngin
     connect(m_processVisibleRowsTimer, &QTimer::timeout, this,
             &NPlaylistController::processVisibleRows);
 
+    // Gapless: the engine reads a pre-cached next track on its streaming thread
+    // (NPlaybackEngineGStreamer::_handleAboutToFinish) instead of emitting a blocking
+    // cross-thread request, so this is Qt::QueuedConnection, NOT BlockingQueued --
+    // the blocking variant deadlocked against main-thread seek/set_state and froze
+    // the UI when scrubbing. The successor is pushed eagerly from
+    // on_playbackEngine_mediaChanged() and setRepeatMode().
     connect(&m_playbackEngine, SIGNAL(nextMediaRequested()), this,
-            SLOT(on_playbackEngine_prepareNextMediaRequested()), Qt::BlockingQueuedConnection);
+            SLOT(on_playbackEngine_prepareNextMediaRequested()), Qt::QueuedConnection);
     connect(&m_playbackEngine, SIGNAL(mediaFailed(const QString &, int)), this,
             SLOT(on_playbackEngine_mediaFailed(const QString &, int)));
     connect(&m_playbackEngine, SIGNAL(mediaChanged(const QString &, int)), this,
@@ -81,6 +87,7 @@ void NPlaylistController::setRepeatMode(bool repeat)
     }
     m_settings.setValue("Repeat", repeat);
     emit repeatModeChanged(repeat);
+    on_playbackEngine_prepareNextMediaRequested(); // successor depends on repeat mode
 }
 
 void NPlaylistController::setRowsPerPage(int rows)
@@ -443,6 +450,7 @@ void NPlaylistController::on_playbackEngine_prepareNextMediaRequested()
     }
 
     if (nextPlayingRow < 0) {
+        m_playbackEngine.nextMediaRespond("", 0); // no successor; clear the gapless cache
         return;
     }
 
@@ -474,6 +482,7 @@ void NPlaylistController::on_playbackEngine_mediaChanged(const QString &file, in
     }
 
     m_model->setData(newPlayingRow, NPlaylistModel::IsPlayingtRole, true);
+    on_playbackEngine_prepareNextMediaRequested(); // pre-cache the successor for gapless
 }
 
 void NPlaylistController::on_playbackEngine_mediaFinished(const QString &, int id)

--- a/src/plugins/pluginGstreamer/playbackEngineGstreamer.cpp
+++ b/src/plugins/pluginGstreamer/playbackEngineGstreamer.cpp
@@ -32,10 +32,40 @@
 static void _on_about_to_finish(GstElement *, gpointer userData)
 {
     NPlaybackEngineGStreamer *obj = reinterpret_cast<NPlaybackEngineGStreamer *>(userData);
-    if ((obj->durationMsec() < CROSSFADING_MIN_DURATION_MSEC) || obj->_nextMediaRequestBlocked()) {
+    obj->_handleAboutToFinish();
+}
+
+void NPlaybackEngineGStreamer::_handleAboutToFinish()
+{
+    // Runs on a GStreamer streaming thread. Read the next track pre-cached from
+    // the GUI thread (via nextMediaRespond) and hand its URI to playbin directly
+    // here -- the documented gapless pattern. We never block on, or call back
+    // into, the GUI thread, so there is no lock inversion with main-thread
+    // pipeline ops (which is what froze the UI when scrubbing the position bar).
+    QString file;
+    int context;
+    {
+        QMutexLocker locker(&m_nextMediaMutex);
+        if (m_nextMediaFile.isEmpty()) {
+            return; // no successor prepared -> let the stream EOS and advance
+        }
+        file = m_nextMediaFile;
+        context = m_nextMediaContext;
+        m_pendingMedia = file; // promoted to current media on STREAM_START
+        m_pendingContext = context;
+    }
+
+    GError *err = NULL;
+    gchar *uri = g_filename_to_uri(QFileInfo(file).absoluteFilePath().toUtf8().constData(), NULL,
+                                   &err);
+    if (!uri) {
+        if (err) {
+            g_error_free(err);
+        }
         return;
     }
-    obj->_emitNextMediaRequest();
+    g_object_set(m_playbin, "uri", uri, NULL);
+    g_free(uri);
 }
 
 N::PlaybackState NPlaybackEngineGStreamer::fromGstState(GstState state) const
@@ -109,11 +139,11 @@ void NPlaybackEngineGStreamer::init()
     m_positionPostponed = false;
     m_currentMedia = "";
     m_currentContext = 0;
-    m_bkpMedia = "";
-    m_bkpContext = 0;
     m_durationNsec = GST_CLOCK_TIME_NONE;
-    m_crossfading = false;
-    m_nextMediaRequestBlock = false;
+    m_nextMediaFile = "";
+    m_nextMediaContext = 0;
+    m_pendingMedia = "";
+    m_pendingContext = 0;
 
     m_checkStatusTimer = new QTimer(this);
     connect(m_checkStatusTimer, SIGNAL(timeout()), this, SLOT(checkStatus()));
@@ -131,7 +161,9 @@ void NPlaybackEngineGStreamer::init()
         GstMessage *msg;
         while ((msg = gst_bus_pop(bus)) != NULL) {
             processGstMessage(msg);
+            gst_message_unref(msg); // gst_bus_pop transfers ownership
         }
+        gst_object_unref(bus); // gst_pipeline_get_bus returns a new ref
     });
 
     m_init = true;
@@ -187,9 +219,12 @@ bool NPlaybackEngineGStreamer::gstSetFile(const QString &file, int context, bool
 
 void NPlaybackEngineGStreamer::setMedia(const QString &file, int context)
 {
-    m_crossfading = false;
     m_position = 0.0;
-    m_nextMediaRequestBlock = true;
+    {
+        QMutexLocker locker(&m_nextMediaMutex);
+        m_nextMediaFile = "";
+        m_pendingMedia = "";
+    }
 
     if (!gstSetFile(file, context, false)) {
         return;
@@ -198,13 +233,12 @@ void NPlaybackEngineGStreamer::setMedia(const QString &file, int context)
 
 void NPlaybackEngineGStreamer::nextMediaRespond(const QString &file, int context)
 {
-    if (!m_crossfading) {
-        return;
-    }
-    m_bkpMedia = m_currentMedia;
-    m_bkpContext = m_currentContext;
-
-    gstSetFile(file, context, true);
+    // Eager push from the playlist (GUI thread): cache the track to play next so
+    // the streaming-thread about-to-finish callback can switch to it gaplessly
+    // without bouncing back to the GUI thread. file == "" clears the cache.
+    QMutexLocker locker(&m_nextMediaMutex);
+    m_nextMediaFile = file;
+    m_nextMediaContext = context;
 }
 
 qreal NPlaybackEngineGStreamer::speed() const
@@ -249,14 +283,6 @@ void NPlaybackEngineGStreamer::setPosition(qreal pos)
         return;
     }
 
-    if (m_crossfading) {
-        // abort cross-fading:
-        if (!gstSetFile(m_bkpMedia, m_bkpContext, false)) {
-            fail();
-            return;
-        }
-        gst_element_set_state(m_playbin, GST_STATE_PLAYING);
-    }
     m_position = pos;
     m_positionPostponed = true;
 }
@@ -267,13 +293,6 @@ void NPlaybackEngineGStreamer::jump(qint64 msec)
         return;
     }
 
-    if (m_crossfading) {
-        // abort cross-fading:
-        if (!gstSetFile(m_bkpMedia, m_bkpContext, false)) {
-            fail();
-            return;
-        }
-    }
     m_position += ((qreal)msec * NSEC_IN_MSEC) / m_durationNsec;
     m_positionPostponed = true;
 }
@@ -318,8 +337,11 @@ void NPlaybackEngineGStreamer::pause()
 
 void NPlaybackEngineGStreamer::stop()
 {
-    m_crossfading = false;
-    m_nextMediaRequestBlock = true;
+    {
+        QMutexLocker locker(&m_nextMediaMutex);
+        m_nextMediaFile = "";
+        m_pendingMedia = "";
+    }
     gst_element_set_state(m_playbin, GST_STATE_NULL);
     m_durationNsec = 0;
     m_position = 0.0;
@@ -391,8 +413,15 @@ void NPlaybackEngineGStreamer::processGstMessage(GstMessage *msg)
             break;
         }
         case GST_MESSAGE_STREAM_START: {
-            m_crossfading = false;
-            m_nextMediaRequestBlock = false;
+            {
+                QMutexLocker locker(&m_nextMediaMutex);
+                if (!m_pendingMedia.isEmpty()) { // a gapless transition just completed
+                    m_currentMedia = m_pendingMedia;
+                    m_currentContext = m_pendingContext;
+                    m_pendingMedia = "";
+                    m_position = 0.0;
+                }
+            }
             if (m_speed != 1.0) {
                 m_speedPostponed = true;
             }
@@ -474,15 +503,4 @@ void NPlaybackEngineGStreamer::fail()
 
     m_currentMedia = "";
     m_currentContext = 0;
-}
-
-void NPlaybackEngineGStreamer::_emitNextMediaRequest()
-{
-    m_crossfading = true;
-    emit nextMediaRequested();
-}
-
-bool NPlaybackEngineGStreamer::_nextMediaRequestBlocked()
-{
-    return m_nextMediaRequestBlock;
 }

--- a/src/plugins/pluginGstreamer/playbackEngineGstreamer.h
+++ b/src/plugins/pluginGstreamer/playbackEngineGstreamer.h
@@ -18,6 +18,8 @@
 
 #include <gst/gst.h>
 
+#include <QMutex>
+
 #include "global.h"
 #include "playbackEngineInterface.h"
 #include "plugin.h"
@@ -47,13 +49,15 @@ private:
     bool m_positionPostponed;
     GstState m_gstState;
     gint64 m_durationNsec;
-    bool m_crossfading;
-    bool m_nextMediaRequestBlock;
 
     QString m_currentMedia;
     int m_currentContext;
-    QString m_bkpMedia;
-    int m_bkpContext;
+
+    QMutex m_nextMediaMutex; // guards the four next/pending fields below
+    QString m_nextMediaFile;
+    int m_nextMediaContext;
+    QString m_pendingMedia;
+    int m_pendingContext;
 
     N::PlaybackState fromGstState(GstState state) const;
     bool gstSetFile(const QString &file, int context, bool prepareNext);
@@ -77,8 +81,7 @@ public:
     Q_INVOKABLE qreal speed() const;
     Q_INVOKABLE qreal pitch() const;
 
-    void _emitNextMediaRequest();
-    bool _nextMediaRequestBlocked();
+    void _handleAboutToFinish();
 
 public slots:
     Q_INVOKABLE void setMedia(const QString &file, int context);

--- a/src/plugins/pluginGstreamer/waveformBuilderGstreamer.cpp
+++ b/src/plugins/pluginGstreamer/waveformBuilderGstreamer.cpp
@@ -30,9 +30,17 @@ static void _handleBuffer(GstPad *pad, GstPadProbeInfo *info, gpointer userData)
 {
     QMutexLocker locker(&_mutex);
 
-    int nChannels;
-    GstStructure *structure = gst_caps_get_structure(gst_pad_get_current_caps(pad), 0);
+    GstCaps *caps = gst_pad_get_current_caps(pad);
+    if (!caps) { // pad not negotiated yet
+        return;
+    }
+    int nChannels = 0;
+    GstStructure *structure = gst_caps_get_structure(caps, 0);
     gst_structure_get_int(structure, "channels", &nChannels);
+    gst_caps_unref(caps); // gst_pad_get_current_caps returns a new ref
+    if (nChannels <= 0) { // missing/invalid channel count; avoid divide-by-zero
+        return;
+    }
 
     GstBuffer *buffer = GST_PAD_PROBE_INFO_BUFFER(info);
     GstMapInfo mapInfo;

--- a/src/plugins/pluginTaglib/coverReaderTaglib.cpp
+++ b/src/plugins/pluginTaglib/coverReaderTaglib.cpp
@@ -42,6 +42,11 @@ void NCoverReaderTaglib::setSource(const QString &file)
 
     if (NTaglib::_tagRef) {
         delete NTaglib::_tagRef;
+        NTaglib::_tagRef = NULL;
+    }
+
+    if (file.isEmpty()) { // release the file
+        return;
     }
 #ifdef WIN32
     NTaglib::_tagRef = new TagLib::FileRef(reinterpret_cast<const wchar_t *>(file.constData()));

--- a/src/plugins/pluginTaglib/tagReaderTaglib.cpp
+++ b/src/plugins/pluginTaglib/tagReaderTaglib.cpp
@@ -302,6 +302,12 @@ QMap<QString, QStringList> NTagReaderTaglib::getTags() const
 
 QMap<QString, QStringList> NTagReaderTaglib::setTags(const QMap<QString, QStringList> &tags)
 {
+    if (!m_isValid) { // workaround to relay the error
+        QMap<QString, QStringList> unsaved;
+        unsaved["Error"] = QStringList() << "Write";
+        return unsaved;
+    }
+
     QMap<QString, QStringList> unsaved = TMapToQMap(
         NTaglib::_tagRef->file()->setProperties(QMapToTMap(tags)));
     if (unsaved.isEmpty()) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -137,7 +137,7 @@ NSettings::NSettings(QObject *parent)
         *.mp3 *.ogg *.mp4 *.wma \
         *.flac *.ape *.wav *.wv *.tta \
         *.mpc *.spx *.opus \
-        *.m4a *.aac *.aiff \
+        *.m4a *.aac *.aiff *.aif *.aifc \
         *.xm *.s3m *.it *.mod")
                                  .simplified());
 


### PR DESCRIPTION
These are backend fixes — all in the GStreamer/TagLib plugins, the playback controller, and settings, so they're independent of the QML UI work. I developed them on a master-based build (where the deadlock fix is test-covered) and ported them here, since this code is shared between the branches.

## The main one: UI deadlock when seeking

playbin's `about-to-finish` runs on a GStreamer **streaming thread**, and `NPlaylistController` wires `nextMediaRequested()` back to the GUI thread over a **`Qt::BlockingQueuedConnection`**. While the streaming thread blocks waiting for the GUI thread, a concurrent main-thread pipeline op — the flushing `gst_element_seek()` in `checkStatus()`, or `set_state()` — blocks on the same stream lock. Classic lock inversion → the whole UI freezes and needs a force-quit. It reproduces when scrubbing the position bar.

**Fix:** drive gapless from a mutex-guarded next-track cache. The controller pushes the successor eagerly (on media-change / repeat-toggle) via `nextMediaRespond()`; `_handleAboutToFinish()` reads it on the streaming thread and sets playbin's `uri` directly — the documented gapless pattern — never blocking on or calling into the GUI thread. `STREAM_START` promotes the pending media on the main thread, so `m_currentMedia` is never written cross-thread. The connection is now `Qt::QueuedConnection`.

## Also included

- **bus-poll leak:** `gst_pipeline_get_bus()` + `gst_bus_pop()` both transfer ownership but weren't unref'd → leaked every 50 ms during playback.
- **waveform builder:** unref the caps from `gst_pad_get_current_caps()`, guard a NULL pad-caps deref and a zero-channel divide-by-zero.
- **tagReader::setTags:** return a Write error instead of dereferencing a NULL file ref when the source failed to open.
- **coverReader::setSource(""):** actually release the file, matching the tag reader.
- **.aif / .aifc:** add to the default file filter (only `*.aiff` was listed, so `.aif` drag-drops were silently rejected).
- removed the now-dead crossfade state that the pre-cache replaces.

## Verification

Builds cleanly on Qt 6.11 (Homebrew); the plugins load and the app runs. The deadlock/gapless logic is the same change I made on a master-based build, where it's covered by `tests/testPlaylistWidget::testAutoPlay`. Manual playback/gapless testing on this branch is still worth doing.

One unrelated thing I hit while testing on macOS, flagging in case it's useful: on Qt 6.5+ the QML UI only starts with `QT_QUICK_CONTROLS_STYLE=Basic`. Under the default native macOS style it **segfaults** at startup — the skins customize controls the native style reports as non-customizable (`QPainter::begin: Paint device returned engine == 0`). This is pre-existing and independent of these backend changes.

Happy to split these into separate PRs or adjust anything.
